### PR TITLE
Setting utf8 as charset in doctrine

### DIFF
--- a/src/Loader.php
+++ b/src/Loader.php
@@ -253,7 +253,11 @@ class Loader extends Singleton{
                 'user'     => DB_USER,
                 'password' => DB_PASSWORD,
                 'dbname'   => DB_NAME,
-                'host'     => DB_HOST
+                'host'     => DB_HOST,
+                'charset'  => 'utf8',
+                'driverOptions' => array(
+                    1002 => 'SET NAMES utf8'
+                )
             );
 
             $em = EntityManager::create($dbParams, $config, $evm);


### PR DESCRIPTION
Hi,

I would like to submit you this modification in order to set UTF8 as base charset used in doctrine configuration when loading WonderWp Framework.

Thank you!

Kévin